### PR TITLE
Fix vscode python interpreter path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -330,7 +330,7 @@
 
     // Python & Pylance Setup
     "python.languageServer": "Pylance",
-    "python.pythonPath": "${workspaceFolder}/app/kit/python/python.exe",
+    "python.defaultInterpreterPath": "${workspaceFolder}/app/kit/python/python.exe",
 
     // We use "black" as a formatter:
     "python.formatting.provider": "black",


### PR DESCRIPTION
The correct configuration key for the python interpreter path is `defaultInterpreterPath`. See https://code.visualstudio.com/docs/python/environments#_manually-specify-an-interpreter.